### PR TITLE
Fix outdated Boundary Tool description in Lemon

### DIFF
--- a/objects/toolbutton.gml
+++ b/objects/toolbutton.gml
@@ -9,7 +9,7 @@ event_inherited()
 toolname[0]="Draw (D)#Shift: move/properties#Ctrl: pick"
 toolname[1]="Select (S)#Ctrl+Shift+C/V: copy#using the clipboard"
 toolname[2]="Fill (F)#Left click: Flood Fill#Drag to fill rectangle"
-toolname[3]="Boundary Tool#Left click: Cycle#Right click: Delete"
+toolname[3]="Boundary Tool#Left click: Mark screen as forbidden#Right click: Mark screen as secret#Click again to remove boundary"
 toolname[4]="Thumbnail Tool"
 toolname[7]="Reference Graphic Tool#Left click: move#Right click: load/unload"
 toolname[9]="Spawn Point#Left click: Player Spawn#Right click: Testing Spawn"


### PR DESCRIPTION
Updates the Boundary Tool tooltip to be accurate to its current functionality