### PR TITLE
Door Update [Poker Boll Fix]

### DIFF
--- a/scripts/ssw_tile.gml
+++ b/scripts/ssw_tile.gml
@@ -62,24 +62,18 @@ switch (argument[0]) {
 
     case "flag": {frx=26+fr*2 fry=0 w=2 h=1.5 break}
     case "door": {
-        if !(oneway) {
+        w=2
+        h=2
+        frox=8
+        froy=16
+        if !(oneway || (target="" && nextlevel="")) {
             frx=11+floor(frame)*2
             if (key && frame=0)
             frx=9
-
             fry=8
-            w=2
-            h=2
-            frox=8
-            froy=16
         } else {
             frx=17.5+floor(frame)*2
-
             fry=10
-            w=2
-            h=2
-            frox=8
-            froy=16
         }
     break}
     case "chardoor": {

--- a/scripts/updatedeities.gml
+++ b/scripts/updatedeities.gml
@@ -187,9 +187,13 @@
     break;
     case (door): {
         point=noone
-        if (data[1]!="") with (drawregion.deity) if (obj=door) if (data[0]=other.data[1]) other.point=id
-        if (data[4]!="0") {frame=2}
-        else if (data[3]!="0") {keyed=1 frame=1}
+        //Pointer
+        if (data[2]!="") with (drawregion.deity) if (obj=door) if (data[1]=other.data[2]) other.point=id
+        //Locked Door
+        if (data[4]!="0" && !(data[2]="" && data[3]="")) {keyed=1 frame=1}
+        //One-Way Door
+        else if (data[2]="" && data[3]="") || funnytruefalse(data[5]) {keyed=0 frame=2}
+        //Normal Door
         else {keyed=0 frame=0}
     } break
     case (warpbox): {


### PR DESCRIPTION
Makes doors properly point to door targets and display their properties.

Also makes doors one-way automatically if no next level or target is set so it doesn't need to be done manually by level designers.