### PR TITLE
Minor Bowser update

### DIFF
--- a/SBDX_vanilla/character/bowser/bowser.gml
+++ b/SBDX_vanilla/character/bowser/bowser.gml
@@ -9,7 +9,7 @@ duck,swim,fire,spin,stomp,taunt,superjump1,superjump2,hammer
 #define movelist
 Bowser
 #
-[c]: Shell Spin (ground)
+[dir]+[c]: Shell Spin (ground)
 [a]: Shell Glide (air)
 [up]+[a]: Highjump
 [down]: Groundpound (air)
@@ -839,7 +839,7 @@ if (ckey) {
 			spin=1
 			playsfx(name+"spin") 
 			if (spinplus) {hsp=maxspd*xsc} else {hsp=xsc*3}
-			} else hsp=0
+			} //else hsp=0
         }
     }
     poundlok=1


### PR DESCRIPTION
Movelist updated to show Dir+C for Shell Spin instead of just C

Using C without holding a direction no longer halts Bowser's movement