### PR TITLE
Fixed tags in skintext adding invalid characters to the end of strings

### DIFF
--- a/scripts/draw_skintext.gml
+++ b/scripts/draw_skintext.gml
@@ -38,7 +38,7 @@ repeat l {
             continue
         } else {tagstr+=ch i+=1 continue}
     }
-    if (ch="$") if (string_char_at(str,i+1)="{") {tag=1 i+=2 tagstr="" continue}
+    if (ch="$") if (string_char_at(str,i+1)="{") {tag=1 i+=1 tagstr="" continue}
 
     c=string_pos(ch,global.fontmap)
     arr[j]=c j+=1 cmd[j,0]=0


### PR DESCRIPTION
aka the Retry purple squares issue